### PR TITLE
Make Learndot:edX relation many-to-many

### DIFF
--- a/edxlearndot/migrations/0002_auto_20180319_1550.py
+++ b/edxlearndot/migrations/0002_auto_20180319_1550.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('edxlearndot', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='coursemapping',
+            name='learndot_component_id',
+            field=models.IntegerField(help_text='The numeric ID of the Learndot component.'),
+        ),
+    ]

--- a/edxlearndot/models.py
+++ b/edxlearndot/models.py
@@ -11,7 +11,7 @@ from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 
 class CourseMapping(models.Model):
     """A mapping of edX courses to Learndot components."""
-    learndot_component_id = models.IntegerField(unique=True, help_text="The numeric ID of the Learndot component.")
+    learndot_component_id = models.IntegerField(help_text="The numeric ID of the Learndot component.")
     edx_course_key = CourseKeyField(max_length=255, db_index=True, help_text="The edX course ID.")
 
     class Meta(object):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,12 +20,19 @@ class CourseMappingTestCase(TestCase):
         self.course1_key = CourseKey.from_string("course-v1:Test+TestCourse+201801")
         self.course2_key = CourseKey.from_string("course-v1:Test+TestCourse+201802")
 
-    def test_only_one_course_is_permitted_per_component(self):
+    def test_many_to_many_mapping(self):
+        """
+        You can have more than one Learndot component per edX course, and
+        vice versa, but only one mapping for any pair.
+        """
+        CourseMapping.objects.create(learndot_component_id=1, edx_course_key=self.course1_key)
+        CourseMapping.objects.create(learndot_component_id=1, edx_course_key=self.course2_key)
+        CourseMapping.objects.create(learndot_component_id=2, edx_course_key=self.course1_key)
+        CourseMapping.objects.create(learndot_component_id=2, edx_course_key=self.course2_key)
+
+        self.assertEqual(CourseMapping.objects.count(), 4)
+        self.assertEqual(CourseMapping.objects.filter(edx_course_key=self.course1_key).count(), 2)
+        self.assertEqual(CourseMapping.objects.filter(edx_course_key=self.course2_key).count(), 2)
+
         with self.assertRaises(IntegrityError):
             CourseMapping.objects.create(learndot_component_id=1, edx_course_key=self.course1_key)
-            CourseMapping.objects.create(learndot_component_id=1, edx_course_key=self.course2_key)
-
-    def test_multiple_components_per_course_is_ok(self):
-        CourseMapping.objects.create(learndot_component_id=1, edx_course_key=self.course1_key)
-        CourseMapping.objects.create(learndot_component_id=2, edx_course_key=self.course1_key)
-        self.assertEqual(CourseMapping.objects.filter(edx_course_key=self.course1_key).count(), 2)


### PR DESCRIPTION
You can have more than one Learndot component per edX course, and vice
versa, but only one mapping for any pair.

**Testing instructions**
1. Run migrations to drop the unique constraint on models.CourseMapping.learndot_component_id.
2. Create a mapping between a Learndot component ID and an edX course.
3. Create another mapping from the same Learndot component ID to a different edX course.
4. You should no longer get an error message saying that a mapping already exists with the Learndot component ID.

**Reviewers**
- [ ] @pomegranited 