### PR TITLE
Stop dropped errors, add user option to mgmt cmd

### DIFF
--- a/edxlearndot/learndot.py
+++ b/edxlearndot/learndot.py
@@ -252,7 +252,7 @@ class LearndotAPIClient(LearndotAPIClientBase):
             headers=self.get_api_request_headers(),
             json=contact_query
         )
-        response.raise_for_status()
+
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:

--- a/edxlearndot/management/commands/update_learndot_enrolments.py
+++ b/edxlearndot/management/commands/update_learndot_enrolments.py
@@ -35,9 +35,18 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
+            "-u",
+            "--username",
+            action='append',
+            dest='users',
+            default=[],
+            help=("""If usernames are given, only update enrollments for those users.""")
+        )
+
+        parser.add_argument(
             "course_id",
             nargs="*",
-            help=("""If one or more course IDs are given, only update enrollments for those courses.""")
+            help=("""If course IDs are given, only update enrollments for those courses.""")
         )
 
     def handle(self, *args, **options):
@@ -78,7 +87,10 @@ class Command(BaseCommand):
 
             log.info("Processing enrollments in course %s", cm.edx_course_key)
 
-            enrollments = CourseEnrollment.objects.filter(course=cm.edx_course_key)
+            enrollments = CourseEnrollment.objects.filter(course_id=cm.edx_course_key)
+            if options["users"]:
+                enrollments = enrollments.filter(user__username__in=options["users"])
+
             for enrollment in enrollments:
                 contact_id = learndot_client.get_contact_id(enrollment.user)
                 if not contact_id:


### PR DESCRIPTION
In edxlearndot.learndot.get_client_id, a typo resulted in an extra call
to response.raise_for_status outside of the try block, meaning
exceptions raised while talking to Learndot could be silently lost in a
signal handler, with nothing logged.

Add --user option to the update_learndot_enrolments management command,
to reduce the number of enrolments being updated and avoid hitting the
Learndot API call limits.
