### PR TITLE
Add caching to reduce calls to the Learndot API

### DIFF
--- a/edxlearndot/admin.py
+++ b/edxlearndot/admin.py
@@ -4,6 +4,7 @@ Django admin integration
 
 from django.contrib import admin
 
-from edxlearndot.models import CourseMapping
+from edxlearndot.models import CourseMapping, EnrolmentStatusLog
 
 admin.site.register(CourseMapping)
+admin.site.register(EnrolmentStatusLog)

--- a/edxlearndot/learndot.py
+++ b/edxlearndot/learndot.py
@@ -16,6 +16,7 @@ enrolments and edX enrollments.
 
 from __future__ import absolute_import, unicode_literals
 
+import hashlib
 import logging
 import os
 
@@ -148,59 +149,7 @@ class EnrolmentStatus(object):
         return hasattr(cls, status) and getattr(cls, status) == status
 
 
-class LearndotAPIClientBase(object):
-    """
-    Base class for clients of the Learndot API.
-    """
-
-    def get_api_key(self):
-        """
-        Returns the API key for the Learndot v2 API.
-        """
-        raise NotImplementedError
-
-    def get_api_base_url(self):
-        """
-        Returns the base URL for the Learndot v2 API.
-        """
-        raise NotImplementedError
-
-    def get_api_request_headers(self):
-        """
-        Returns the headers required for v2 API calls.
-        """
-        return {
-            "TrainingRocket-Authorization": self.get_api_key(),
-            "Content-Type": "application/json",
-            "Accept": "application/json"
-        }
-
-    def get_contact_search_url(self):
-        """
-        Returns the URL used to find contacts.
-        """
-        return os.path.join(self.get_api_base_url(), "api/rest/v2/manage/contact/search")
-
-    def get_enrolment_search_url(self):
-        """
-        Returns the URL used to find enrolments.
-        """
-        return os.path.join(self.get_api_base_url(), "api/rest/v2/manage/enrolment/search")
-
-    def get_enrolment_management_url_template(self):
-        """
-        Returns a template for the URL used to update enrolments.
-
-        The template URL contains a placeholder into which a numeric
-        enrolment ID should be substituted.
-        """
-        return os.path.join(
-            self.get_api_base_url(),
-            "api/rest/v2/manage/enrolment/{enrolment_id}"
-        )
-
-
-class LearndotAPIClient(LearndotAPIClientBase):
+class LearndotAPIClient(object):
     """
     Client for the live Learndot API.
     """
@@ -233,6 +182,16 @@ class LearndotAPIClient(LearndotAPIClientBase):
             log.fatal(msg)
             raise LearndotAPIException(msg)
 
+    def get_api_request_headers(self):
+        """
+        Returns the headers required for v2 API calls.
+        """
+        return {
+            "TrainingRocket-Authorization": self.get_api_key(),
+            "Content-Type": "application/json",
+            "Accept": "application/json"
+        }
+
     def get_contact_id(self, user):
         """
         Tries to look up a Learndot contact using the edX user record.
@@ -252,7 +211,8 @@ class LearndotAPIClient(LearndotAPIClientBase):
 
         contact_query = {"email": [user.email]}
 
-        contact_cache_key = 'edxlearndot-contact-{}'.format(user.id)
+        hashed_email = hashlib.md5(user.email).hexdigest()
+        contact_cache_key = 'edxlearndot-contact-{}-{}'.format(hashed_email, user.id)
 
         cached_contact_id = cache.get(contact_cache_key)
         if cached_contact_id is not None:
@@ -287,6 +247,30 @@ class LearndotAPIClient(LearndotAPIClientBase):
             cache.set(contact_cache_key, contact_id)
 
         return contact_id
+
+    def get_contact_search_url(self):
+        """
+        Returns the URL used to find contacts.
+        """
+        return os.path.join(self.get_api_base_url(), "api/rest/v2/manage/contact/search")
+
+    def get_enrolment_search_url(self):
+        """
+        Returns the URL used to find enrolments.
+        """
+        return os.path.join(self.get_api_base_url(), "api/rest/v2/manage/enrolment/search")
+
+    def get_enrolment_management_url(self, enrolment_id):
+        """
+        Returns a template for the URL used to update enrolments.
+
+        The template URL contains a placeholder into which a numeric
+        enrolment ID should be substituted.
+        """
+        return os.path.join(
+            self.get_api_base_url(),
+            "api/rest/v2/manage/enrolment/{}".format(enrolment_id)
+        )
 
     def get_enrolment_id(self, contact_id, component_id):
         """
@@ -392,6 +376,11 @@ class LearndotAPIClient(LearndotAPIClientBase):
             LearndotAPIException: if the requested status is invalid, or
                 Requests throws anything.
         """
+        if not enrolment_id:
+            msg = "Enrolment_id can not be None"
+            log.error(msg)
+            raise LearndotAPIException(msg)
+
         log.info("Setting Learndot enrolment status to %s for enrolment %s.", status, enrolment_id)
 
         if not EnrolmentStatus.is_valid(status):
@@ -402,7 +391,7 @@ class LearndotAPIClient(LearndotAPIClientBase):
         if not unconditional:
             try:
                 enrolment_status = EnrolmentStatusLog.objects.get(learndot_enrolment_id=enrolment_id)
-                if enrolment_status.status == EnrolmentStatus.PASSED:
+                if enrolment_status.status == status:
                     log.info(
                         "Learndot enrolment was logged as set to %s at %s, so skipping update.",
                         enrolment_status.status,
@@ -413,7 +402,7 @@ class LearndotAPIClient(LearndotAPIClientBase):
                 pass
 
         response = requests.post(
-            self.get_enrolment_management_url_template().format(enrolment_id=enrolment_id),
+            self.get_enrolment_management_url(enrolment_id),
             headers=self.get_api_request_headers(),
             json={"status": status}
         )
@@ -440,71 +429,41 @@ class LearndotAPIClient(LearndotAPIClientBase):
         except (IntegrityError, MultipleObjectsReturned) as e:
             log.error("Error recording enrolment status update: %s", e)
 
-
-class LearndotAPIClientMock(LearndotAPIClientBase):
-    """
-    Mock client for tests.
-    """
-    DOES_NOT_EXIST_ID = 1
-
-    enrolments = {}
-
-    def get_api_key(self):
-        return "bababababababababababa"
-
-    def get_api_base_url(self):
-        return "https://localhost/learndot/v2/api"
-
-    def get_contact_id(self, user):
+    def set_enrolment_status_to_passed(self, enrolment_id, unconditional=False):
         """
-        Mock implementation just returns the user ID as the contact ID.
-
-        If the user is None, or the user ID is self.DOES_NOT_EXIST_ID,
-        the mock contact does not exist.
+        Sets the status of a Learndot enrollment record to PASSED.
+        Arguments:
+            enrolment_id (int): the numeric Learndot enrollment ID
+            unconditional (bool): whether to unconditionally send the new
+                                  status to Learndot, instead of checking
+                                  EnrolmentStatusLog records to see if it
+                                  has already been sent.
+        Returns:
+            None
+        Raises:
+            LearndotAPIException: if the requested status is invalid, or
+                Requests throws anything.
         """
+        self.set_enrolment_status(enrolment_id, EnrolmentStatus.PASSED, unconditional)
 
-        if user is None or user.id == self.DOES_NOT_EXIST_ID:
-            return None
-
-        return user.id
-
-    def get_enrolment_id(self, contact_id, component_id):
+    def check_if_enrolment_and_set_status_to_passed(self, contact_id, component_id, unconditional=False):
         """
-        Mock implementation just returns the concatentation of the two IDs.
-
-        If either is None or self.DOES_NOT_EXIST_ID, the mock
-        enrolment does not exist.
+        Sets the status of a Learndot enrollment record to PASSED if enrollment_id is found.
+        Arguments:
+            contact_id (int): the numeric Learndot enrollment ID
+            component_id (int): the numeric Learndot component ID.
+            unconditional (bool): whether to unconditionally send the new
+                                  status to Learndot, instead of checking
+                                  EnrolmentStatusLog records to see if it
+                                  has already been sent.
+        Returns:
+            None
+        Raises:
+            LearndotAPIException: if the requested status is invalid, or
+                Requests throws anything.
         """
-
-        if (
-                contact_id is None or component_id is None or
-                contact_id == self.DOES_NOT_EXIST_ID or component_id == self.DOES_NOT_EXIST_ID
-        ):
-            return None
-
-        return int('{}{}'.format(contact_id, component_id))
-
-    def set_enrolment_status(self, enrolment_id, status):
-        """
-        Stores the status under the given enrolment ID in self.enrolments.
-        """
-        if not EnrolmentStatus.is_valid(status):
-            msg = "Invalid enrolment status \"{}\".".format(status)
-            log.error(msg)
-            raise LearndotAPIException(msg)
-
-        if enrolment_id == self.DOES_NOT_EXIST_ID:
-            # the real API would 404
-            msg = "Error trying to set status of enrolment {} to {}: not found".format(enrolment_id, status, )
-            raise LearndotAPIException(msg)
-
-        self.enrolments[enrolment_id] = status
-
-        try:
-            enrolment_status_log, _created = EnrolmentStatusLog.objects.get_or_create(
-                learndot_enrolment_id=enrolment_id
-            )
-            enrolment_status_log.status = status
-            enrolment_status_log.save()
-        except (IntegrityError, MultipleObjectsReturned) as e:
-            log.error("Error recording enrolment status update: %s", e)
+        enrolment_id = self.get_enrolment_id(contact_id, component_id)
+        if not enrolment_id:
+            log.error("No enrolment found for contact %s, component %s", contact_id, component_id)
+            return
+        self.set_enrolment_status(enrolment_id, EnrolmentStatus.PASSED, unconditional=unconditional)

--- a/edxlearndot/management/commands/update_learndot_enrolments.py
+++ b/edxlearndot/management/commands/update_learndot_enrolments.py
@@ -19,7 +19,7 @@ from lms.djangoapps.grades.config import should_persist_grades
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 from student.models import CourseEnrollment
 
-from edxlearndot.learndot import EnrolmentStatus, LearndotAPIClient, LearndotAPIException
+from edxlearndot.learndot import LearndotAPIClient
 from edxlearndot.models import CourseMapping
 
 
@@ -78,12 +78,12 @@ class Command(BaseCommand):
         if course_key_list:
             course_mappings = course_mappings.filter(edx_course_key__in=course_key_list)
 
-        if course_mappings.count() == 0:
+        if not course_mappings.exists():
             if options["course_id"]:
                 log.error("No course mappings were found for your specified course IDs.")
             else:
                 log.error("No course mappings were found.")
-                sys.exit(1)
+            sys.exit(1)
 
         learndot_client = LearndotAPIClient()
 
@@ -107,15 +107,12 @@ class Command(BaseCommand):
             for enrollment in enrollments:
                 contact_id = learndot_client.get_contact_id(enrollment.user)
                 if not contact_id:
-                    log.error("Could not locate Learndot contact for user %s", enrollment.user)
+                    log.info(
+                        "Not setting enrolment status for user %s in course %s, because contact_id is None .",
+                        enrollment.user,
+                        cm.edx_course_key
+                    )
                     continue
-
-                enrolment_id = learndot_client.get_enrolment_id(contact_id, cm.learndot_component_id)
-
-                if not enrolment_id:
-                    log.error("No enrolment found for contact %s, component %s", contact_id, cm.learndot_component_id)
-                    continue
-
                 #
                 # Disturbingly enough, if persistent grades are not
                 # enabled, it just takes looking up the grade to get
@@ -140,11 +137,8 @@ class Command(BaseCommand):
                     )
                 elif course_grade.passed and should_persist_grades(cm.edx_course_key):
                     log.info("Grades are persistent; explicitly updating Learndot enrolment.")
-                    try:
-                        learndot_client.set_enrolment_status(
-                            enrolment_id,
-                            EnrolmentStatus.PASSED,
-                            unconditional=options["unconditional"]
-                        )
-                    except LearndotAPIException as e:
-                        log.error("Could not set status of enrolment %s: %s", enrolment_id, e)
+                    learndot_client.check_if_enrolment_and_set_status_to_passed(
+                        contact_id,
+                        cm.learndot_component_id,
+                        unconditional=options["unconditional"]
+                    )

--- a/edxlearndot/migrations/0003_auto_20180327_1442.py
+++ b/edxlearndot/migrations/0003_auto_20180327_1442.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('edxlearndot', '0002_auto_20180319_1550'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='EnrolmentStatusLog',
+            fields=[
+                ('learndot_enrolment_id', models.BigIntegerField(help_text='The numeric ID of the Learndot enrolment.', serialize=False, primary_key=True)),
+                ('updated_at', models.DateTimeField(help_text='The timestamp of the last change to this enrolment.', auto_now=True)),
+                ('status', models.TextField(help_text='The last status sent to Learndot.')),
+            ],
+        ),
+        migrations.AlterField(
+            model_name='coursemapping',
+            name='learndot_component_id',
+            field=models.BigIntegerField(help_text='The numeric ID of the Learndot component.'),
+        ),
+    ]

--- a/edxlearndot/models.py
+++ b/edxlearndot/models.py
@@ -11,7 +11,7 @@ from opaque_keys.edx.django.models import CourseKeyField
 
 class CourseMapping(models.Model):
     """A mapping of edX courses to Learndot components."""
-    learndot_component_id = models.IntegerField(help_text="The numeric ID of the Learndot component.")
+    learndot_component_id = models.BigIntegerField(help_text="The numeric ID of the Learndot component.")
     edx_course_key = CourseKeyField(max_length=255, db_index=True, help_text="The edX course ID.")
 
     class Meta(object):
@@ -25,4 +25,28 @@ class CourseMapping(models.Model):
         return "learndot_component_id={}, edx_course_key={}".format(
             self.learndot_component_id,
             self.edx_course_key
+        )
+
+class EnrolmentStatusLog(models.Model):
+    """A record of an update to a Learndot enrolment."""
+    learndot_enrolment_id = models.BigIntegerField(
+        primary_key=True,
+        help_text="The numeric ID of the Learndot enrolment."
+    )
+    updated_at = models.DateTimeField(auto_now=True, help_text="The timestamp of the last change to this enrolment.")
+    status = models.TextField(
+        help_text="The last status sent to Learndot."
+    )
+
+    class Meta(object):
+        app_label = "edxlearndot"
+
+    def __str__(self):
+        return self.__unicode__().encode("utf8")
+
+    def __unicode__(self):
+        return "learndot_enrolment_id={}, status={} at {}".format(
+            self.learndot_enrolment_id,
+            self.status,
+            self.updated_at
         )

--- a/edxlearndot/signals.py
+++ b/edxlearndot/signals.py
@@ -48,12 +48,5 @@ def listen_for_passing_grade(sender, user, course_id, **kwargs):  # pylint: disa
 
             try:
                 learndot_client.set_enrolment_status(enrolment_id, EnrolmentStatus.PASSED)
-                log.info(
-                    "Enrolment status set to %s for enrolment %s of learner %s in course %s",
-                    EnrolmentStatus.PASSED,
-                    enrolment_id,
-                    user,
-                    course_id
-                )
             except LearndotAPIException as e:
                 log.error("Could not set status of enrolment %s: %s", enrolment_id, e)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -11,3 +11,4 @@ pytz
 sortedcontainers
 tox
 xblock
+responses

--- a/tests/test_learndot.py
+++ b/tests/test_learndot.py
@@ -3,17 +3,22 @@ Test the Learndot API
 """
 
 from __future__ import absolute_import, unicode_literals
+from mock import patch
 
-import unittest
+import responses
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
 
 from edxlearndot.learndot import (
-    EnrolmentStatus, LearndotAPIClientMock, LearndotAPIException,
+    EnrolmentStatus, LearndotAPIException,
     compare_enrolment_sort_keys, sort_enrolments_by_expiry
 )
 from edxlearndot.models import EnrolmentStatusLog
 
+from .utils import LearndotAPIClientMock
 
-class TestEnrolmentSorting(unittest.TestCase):
+
+class TestEnrolmentSorting(TestCase):
     """
     Test that lists of enrolments in API results can be sorted properly.
     """
@@ -204,7 +209,7 @@ class TestEnrolmentSorting(unittest.TestCase):
             sort_enrolments_by_expiry(enrolment_list)
 
 
-class TestEnrolmentStatus(unittest.TestCase):
+class TestEnrolmentStatus(TestCase):
     """
     Test for valid values in edxlearndot.learndot.EnrolmentStatus.
     """
@@ -213,7 +218,7 @@ class TestEnrolmentStatus(unittest.TestCase):
         self.assertFalse(EnrolmentStatus.is_valid("BUNGLED"))
 
 
-class TestLearndot(unittest.TestCase):
+class TestLearndot(TestCase):
     """
     Test edxlearndot.learndot.
 
@@ -221,22 +226,67 @@ class TestLearndot(unittest.TestCase):
     what we can test, but we can use a mock client to check tangents
     like the EnrolmentStatusLog recording.
     """
+    def setUp(self):
+        self.user = User.objects.create(username="test", email="test@gmail.com", password="test")
+        self.client = LearndotAPIClientMock()
+        super(TestLearndot, self).setUp()
+
+    def test_get_contact_id(self):
+        """
+        Test get_contact_id succeeds
+        """
+        self.assertEqual(self.client.get_contact_id(self.user), 1)
+
+    @patch('edxlearndot.learndot.log')
+    def test_get_contact_id_uses_cache(self, mock_logger):
+        """
+        Test get_contact_id uses cache
+        """
+        self.client.get_contact_id(self.user)
+        mock_logger.info.assert_called_with("Using cached contact ID %s", 1)
+
+    def test_get_api_key(self):
+        """
+        Test that get_api_key succeeds when LEARNDOT_API_KEY is set
+        """
+        self.assertEqual(self.client.get_api_key(), 'test')
+
+    def test_get_api_base_url(self):
+        """
+        Test that API KEY is returned correctly from settings
+        """
+        self.assertEqual(self.client.get_api_base_url(), 'https://localhost/learndot/v2/api')
+
+    def test_get_enrolment_id(self):
+        """
+        Test get_enrolment_id succeeds
+        """
+        self.assertEqual(self.client.get_enrolment_id(1, 2), 1)
+
+    @patch('edxlearndot.learndot.log')
+    def test_get_enrolment_id_uses_cache(self, mock_logger):
+        self.client.get_enrolment_id(1, 2)
+        mock_logger.info.assert_called_with("Using cached enrolment ID %s", 1)
 
     def test_set_enrolment_status_success_is_logged(self):
         """
         Test that a successful update is logged locally.
         """
-        client = LearndotAPIClientMock()
-
-        client.set_enrolment_status(2, "PASSED")
-        self.assertEqual(EnrolmentStatusLog.objects.filter(learndot_enrolment_id=2).count(), 1)
+        self.client.set_enrolment_status(1, "PASSED")
+        self.assertTrue(EnrolmentStatusLog.objects.filter(learndot_enrolment_id=1).exists())
 
     def test_set_enrolment_status_failure_is_not_logged(self):
         """
         Test that a failed update creates no local status log records.
         """
-        client = LearndotAPIClientMock()
-
         with self.assertRaises(LearndotAPIException):
-            client.set_enrolment_status(client.DOES_NOT_EXIST_ID, "PASSED")
-        self.assertEqual(EnrolmentStatusLog.objects.filter(learndot_enrolment_id=1).count(), 0)
+            self.client.set_enrolment_status(2, "INVALID")
+        self.assertFalse(EnrolmentStatusLog.objects.filter(learndot_enrolment_id=2).exists())
+
+    def test_check_if_enrolment_and_set_status_to_passed_is_logged(self):
+        """
+        Test that the update log has status "PASSED".
+        """
+        self.client.set_enrolment_status(1, "IN_PROGRESS")
+        self.client.check_if_enrolment_and_set_status_to_passed(1, 2)
+        self.assertEqual(EnrolmentStatusLog.objects.get(learndot_enrolment_id=1).status, "PASSED")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,55 @@
+""" This is utils module for tests """
+import responses
+
+from django.test import override_settings
+
+from edxlearndot.learndot import LearndotAPIClient, EnrolmentStatus
+
+
+class LearndotAPIClientMock(LearndotAPIClient):
+    """
+    Mock client for tests.
+    """
+
+    @override_settings(LEARNDOT_API_KEY='test')
+    def get_api_key(self):
+        return super(LearndotAPIClientMock, self).get_api_key()
+    
+    @override_settings(LEARNDOT_API_BASE_URL='https://localhost/learndot/v2/api')
+    def get_api_base_url(self):
+        return super(LearndotAPIClientMock, self).get_api_base_url()
+
+    @responses.activate
+    def get_contact_id(self, user):
+        """
+        Mock response returns for get_contact.
+        """
+        responses.add(
+            responses.POST,
+            self.get_contact_search_url(),
+            json={"results": [{"id": 1, "_displayName_": "Test Name", "email": "test@gmail.com"}]}
+        )
+        return super(LearndotAPIClientMock, self).get_contact_id(user)
+
+    @responses.activate
+    def get_enrolment_id(self, contact_id, component_id):
+        """
+        Mock response for get_enrolment.
+        """
+        response = responses.add(
+            responses.POST,
+            self.get_enrolment_search_url(),
+            json={"results": [{"id": 1, "status": EnrolmentStatus.IN_PROGRESS}]}
+        )
+        return super(LearndotAPIClientMock, self).get_enrolment_id(contact_id, component_id)
+
+    @responses.activate
+    def set_enrolment_status(self, enrolment_id, status, unconditional=False):
+        """
+        Mock response from set enrolment status
+        """
+        response = responses.add(
+            responses.POST,
+            self.get_enrolment_management_url(enrolment_id)
+        )
+        return super(LearndotAPIClientMock, self).set_enrolment_status(enrolment_id, status)


### PR DESCRIPTION
To avoid hitting Learndot's API rate limits, introduce caching of
contact and enrolment ID lookups, and log any enrolment status updates
in a new Django model, edxlearndot.models.EnrolmentStatusLog.

The signal handler will now not attempt to update the Learndot enrolment
if the record shows it should already have the current status. The
management command has a --force option to skip this check and
unconditionally update Learndot.