### PR TITLE
Add caching to reduce calls to the Learndot API

### DIFF
--- a/edxlearndot/admin.py
+++ b/edxlearndot/admin.py
@@ -4,6 +4,7 @@ Django admin integration
 
 from django.contrib import admin
 
-from edxlearndot.models import CourseMapping
+from edxlearndot.models import CourseMapping, EnrolmentStatusLog
 
 admin.site.register(CourseMapping)
+admin.site.register(EnrolmentStatusLog)

--- a/edxlearndot/migrations/0003_auto_20180327_1442.py
+++ b/edxlearndot/migrations/0003_auto_20180327_1442.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('edxlearndot', '0002_auto_20180319_1550'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='EnrolmentStatusLog',
+            fields=[
+                ('learndot_enrolment_id', models.BigIntegerField(help_text='The numeric ID of the Learndot enrolment.', serialize=False, primary_key=True)),
+                ('updated_at', models.DateTimeField(help_text='The timestamp of the last change to this enrolment.', auto_now=True)),
+                ('status', models.TextField(help_text='The last status sent to Learndot.')),
+            ],
+        ),
+        migrations.AlterField(
+            model_name='coursemapping',
+            name='learndot_component_id',
+            field=models.BigIntegerField(help_text='The numeric ID of the Learndot component.'),
+        ),
+    ]

--- a/edxlearndot/models.py
+++ b/edxlearndot/models.py
@@ -11,7 +11,7 @@ from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 
 class CourseMapping(models.Model):
     """A mapping of edX courses to Learndot components."""
-    learndot_component_id = models.IntegerField(help_text="The numeric ID of the Learndot component.")
+    learndot_component_id = models.BigIntegerField(help_text="The numeric ID of the Learndot component.")
     edx_course_key = CourseKeyField(max_length=255, db_index=True, help_text="The edX course ID.")
 
     class Meta(object):
@@ -25,4 +25,28 @@ class CourseMapping(models.Model):
         return "learndot_component_id={}, edx_course_key={}".format(
             self.learndot_component_id,
             self.edx_course_key
+        )
+
+class EnrolmentStatusLog(models.Model):
+    """A record of an update to a Learndot enrolment."""
+    learndot_enrolment_id = models.BigIntegerField(
+        primary_key=True,
+        help_text="The numeric ID of the Learndot enrolment."
+    )
+    updated_at = models.DateTimeField(auto_now=True, help_text="The timestamp of the last change to this enrolment.")
+    status = models.TextField(
+        help_text="The last status sent to Learndot."
+    )
+
+    class Meta(object):
+        app_label = "edxlearndot"
+
+    def __str__(self):
+        return self.__unicode__().encode("utf8")
+
+    def __unicode__(self):
+        return "learndot_enrolment_id={}, status={} at {}".format(
+            self.learndot_enrolment_id,
+            self.status,
+            self.updated_at
         )

--- a/edxlearndot/signals.py
+++ b/edxlearndot/signals.py
@@ -53,12 +53,5 @@ def listen_for_passing_grade(sender, user, course_key, **kwargs):  # pylint: dis
 
             try:
                 learndot_client.set_enrolment_status(enrolment_id, EnrolmentStatus.PASSED)
-                log.info(
-                    "Enrolment status set to %s for enrolment %s of learner %s in course %s",
-                    EnrolmentStatus.PASSED,
-                    enrolment_id,
-                    user,
-                    course_key
-                )
             except LearndotAPIException as e:
                 log.error("Could not set status of enrolment %s: %s", enrolment_id, e)


### PR DESCRIPTION
To avoid hitting Learndot's API rate limits, introduce caching of
contact and enrolment ID lookups, and log any enrolment status updates
in a new Django model, edxlearndot.models.EnrolmentStatusLog.

The signal handler will now not attempt to update the Learndot enrolment
if the record shows it should already have the current status. The
management command has a --force option to skip this check and
unconditionally update Learndot.