### PR TITLE
SE-2671 Python 3 Compatibility for Juniper Upgrade

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,12 +101,20 @@ command, e.g.::
 Running edx-learndot tests
 **************************
 
-The test suite uses tox. If you want to test using the master branch of edx-platform, you can just
-run ``tox``. To test with another release, or another fork, set one or both of the ``OPENEDX_REPO``
-and ``OPENEDX_RELEASE`` environment variables, e.g.::
+The test suite uses ``tox``, so install it into a virtualenv to run the tests::
 
-  OPENEDX_REPO=https://github.com/example/edx-platform OPENEDX_RELEASE=master tox
+  pip install tox
 
+If you want to test using the master branch of edx-platform, you can just run ``tox``.
+
+To test with another release, or another fork, set one or both of the ``OPENEDX_REPO`` and
+``OPENEDX_RELEASE`` environment variables.  To save time cloning this large repo, provide a
+reference to a previously cloned version of edx-platform. e.g.::
+
+  export OPENEDX_REFERENCE_REPO=/path/to/edx-platform
+  export OPENEDX_REPO=https://github.com/open-craft/edx-platform
+  export OPENEDX_RELEASE=opencraft-release/juniper.1
+  tox
 
 .. _Open edX: https://open.edx.org/
 .. _Learndot: https://www.learndot.com

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,20 @@ enrolment records when a learner passes an edX course.
 Installation
 ************
 
+Support
+-------
+
+.. list-table::
+  :widths: 80 20
+  :header-rows: 1
+
+  * - edX Platform Release
+    - Tag
+  * - Juniper
+    - v0.2
+  * - Ironwood
+    - v0.1
+
 Prerequisites
 -------------
 

--- a/edxlearndot/apps.py
+++ b/edxlearndot/apps.py
@@ -20,7 +20,7 @@ class LearndotIntegrationConfig(AppConfig):
     plugin_app = {
         PluginSettings.CONFIG: {
             ProjectType.LMS: {
-                SettingsType.AWS: {
+                SettingsType.PRODUCTION: {
                     PluginSettings.RELATIVE_PATH: u'settings',
                 },
                 SettingsType.COMMON: {

--- a/edxlearndot/learndot.py
+++ b/edxlearndot/learndot.py
@@ -243,7 +243,7 @@ class LearndotAPIClient(object):
 
         contact_query = {"email": [user.email]}
 
-        hashed_email = hashlib.md5(user.email).hexdigest()
+        hashed_email = hashlib.md5(user.email.encode('utf-8')).hexdigest()
         contact_cache_key = 'edxlearndot-contact-{}-{}'.format(hashed_email, user.id)
 
         cached_contact_id = cache.get(contact_cache_key)

--- a/edxlearndot/learndot.py
+++ b/edxlearndot/learndot.py
@@ -20,7 +20,6 @@ import functools
 import hashlib
 import logging
 import os
-import sys
 
 import dateutil.parser
 import requests
@@ -38,17 +37,19 @@ log = logging.getLogger(__name__)
 LEARNDOT_RETRY_WAIT = getattr(settings, 'LEARNDOT_RETRY_WAIT_SECONDS', 5) * 1000
 LEARNDOT_RETRY_MAX_ATTEMPTS = getattr(settings, 'LEARNDOT_RETRY_MAX_ATTEMPTS', 10)
 
-def isPython27():
-    """
-    Checks if it is Python 2.7 or Not
-    """
-    return sys.version_info[0] < 3
-
 def cmp(a, b):
-    if isPython27():
-        return cmp(a, b)
-    else:
-        return (a > b) - (a < b)
+    """
+    Compares elements of two lists
+
+    Compare the two objects x and y and return an integer according
+    to the outcome.
+
+    The return value is:
+        - negative if x < y
+        - zero if x == y
+        - strictly positive if x > y
+    """
+    return (a > b) - (a < b)
 
 class LearndotAPIException(Exception):
     """
@@ -175,10 +176,7 @@ def sort_enrolments_by_expiry(enrolment_list):
         ValueError: if a sorting date can't be parsed
         OverflowError: if a sorting date can't be fit into the largest valid C integer
     """
-    if isPython27():
-        return sorted(enrolment_list, key=extract_enrolment_sort_key, cmp=compare_enrolment_sort_keys)
-    else:
-        return sorted(enrolment_list, key=functools.cmp_to_key(extract_and_compare_enrolment_sort_keys))
+    return sorted(enrolment_list, key=functools.cmp_to_key(extract_and_compare_enrolment_sort_keys))
 
 
 class EnrolmentStatus(object):  # pylint: disable=useless-object-inheritance

--- a/edxlearndot/learndot.py
+++ b/edxlearndot/learndot.py
@@ -42,7 +42,7 @@ def isPython27():
     """
     Checks if it is Python 2.7 or Not
     """
-    return (sys.version_info[0] < 3)
+    return sys.version_info[0] < 3
 
 def cmp(a, b):
     if isPython27():
@@ -138,7 +138,7 @@ def extract_and_compare_enrolment_sort_keys(enrolment1, enrolment2):
     """
     Extracts key for sorting enrolments then compares those enrolment keys
 
-    This function is a combination of both `compare_enrolment_sort_keys` and 
+    This function is a combination of both `compare_enrolment_sort_keys` and
     `extract_enrolment_sort_key` such that it can be used with `functools.cmp_to_key`
 
     Arguments:
@@ -146,7 +146,7 @@ def extract_and_compare_enrolment_sort_keys(enrolment1, enrolment2):
         enrolment2: a dict parsed from a Learndot JSON enrolment
 
     Returns:
-        Output of `compare_enrolment_sort_keys`, which is 
+        Output of `compare_enrolment_sort_keys`, which is
         -1 if t1 < t2, 1 if t1 > t2, or 0 if they're equal
     """
     enrolment1_expiry = extract_enrolment_sort_key(enrolment1)
@@ -175,14 +175,13 @@ def sort_enrolments_by_expiry(enrolment_list):
         ValueError: if a sorting date can't be parsed
         OverflowError: if a sorting date can't be fit into the largest valid C integer
     """
-    
     if isPython27():
         return sorted(enrolment_list, key=extract_enrolment_sort_key, cmp=compare_enrolment_sort_keys)
     else:
         return sorted(enrolment_list, key=functools.cmp_to_key(extract_and_compare_enrolment_sort_keys))
 
 
-class EnrolmentStatus(object):
+class EnrolmentStatus(object):  # pylint: disable=useless-object-inheritance
     """
     Basically an enum of valid Learndot enrolment status values.
 
@@ -202,7 +201,7 @@ class EnrolmentStatus(object):
         return hasattr(cls, status) and getattr(cls, status) == status
 
 
-class LearndotAPIClient(object):
+class LearndotAPIClient(object):  # pylint: disable=useless-object-inheritance
     """
     Client for the live Learndot API.
     """

--- a/edxlearndot/learndot.py
+++ b/edxlearndot/learndot.py
@@ -179,7 +179,7 @@ def sort_enrolments_by_expiry(enrolment_list):
     return sorted(enrolment_list, key=functools.cmp_to_key(extract_and_compare_enrolment_sort_keys))
 
 
-class EnrolmentStatus(object):  # pylint: disable=useless-object-inheritance
+class EnrolmentStatus:
     """
     Basically an enum of valid Learndot enrolment status values.
 
@@ -199,7 +199,7 @@ class EnrolmentStatus(object):  # pylint: disable=useless-object-inheritance
         return hasattr(cls, status) and getattr(cls, status) == status
 
 
-class LearndotAPIClient(object):  # pylint: disable=useless-object-inheritance
+class LearndotAPIClient:
     """
     Client for the live Learndot API.
     """

--- a/edxlearndot/learndot.py
+++ b/edxlearndot/learndot.py
@@ -43,6 +43,12 @@ def isPython27():
     """
     return (sys.version_info[0] < 3)
 
+def cmp(a, b):
+    if isPython27():
+        return cmp(a, b)
+    else:
+        return (a > b) - (a < b)
+
 class LearndotAPIException(Exception):
     """
     A wrapper around exceptions encountered while using the API.

--- a/edxlearndot/learndot.py
+++ b/edxlearndot/learndot.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import, unicode_literals
 import hashlib
 import logging
 import os
+import sys
 
 import dateutil.parser
 import requests
@@ -36,6 +37,11 @@ log = logging.getLogger(__name__)
 LEARNDOT_RETRY_WAIT = getattr(settings, 'LEARNDOT_RETRY_WAIT_SECONDS', 5) * 1000
 LEARNDOT_RETRY_MAX_ATTEMPTS = getattr(settings, 'LEARNDOT_RETRY_MAX_ATTEMPTS', 10)
 
+def isPython27():
+    """
+    Checks if it is Python 2.7 or Not
+    """
+    return (sys.version_info[0] < 3)
 
 class LearndotAPIException(Exception):
     """

--- a/edxlearndot/models.py
+++ b/edxlearndot/models.py
@@ -14,7 +14,7 @@ class CourseMapping(models.Model):
     learndot_component_id = models.BigIntegerField(help_text="The numeric ID of the Learndot component.")
     edx_course_key = CourseKeyField(max_length=255, db_index=True, help_text="The edX course ID.")
 
-    class Meta(object):
+    class Meta(object):  # pylint: disable=useless-object-inheritance
         app_label = "edxlearndot"
         unique_together = ("learndot_component_id", "edx_course_key")
 
@@ -38,7 +38,7 @@ class EnrolmentStatusLog(models.Model):
         help_text="The last status sent to Learndot."
     )
 
-    class Meta(object):
+    class Meta(object):  # pylint: disable=useless-object-inheritance
         app_label = "edxlearndot"
 
     def __str__(self):

--- a/edxlearndot/models.py
+++ b/edxlearndot/models.py
@@ -14,7 +14,7 @@ class CourseMapping(models.Model):
     learndot_component_id = models.BigIntegerField(help_text="The numeric ID of the Learndot component.")
     edx_course_key = CourseKeyField(max_length=255, db_index=True, help_text="The edX course ID.")
 
-    class Meta(object):  # pylint: disable=useless-object-inheritance
+    class Meta:
         app_label = "edxlearndot"
         unique_together = ("learndot_component_id", "edx_course_key")
 
@@ -38,7 +38,7 @@ class EnrolmentStatusLog(models.Model):
         help_text="The last status sent to Learndot."
     )
 
-    class Meta(object):  # pylint: disable=useless-object-inheritance
+    class Meta:
         app_label = "edxlearndot"
 
     def __str__(self):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'tests'
     ],
     install_requires=[
-        "django>=2.2, >3, <3.1",
+        "django>=2.2,<3",
         "edx-opaque-keys",
         "python-dateutil",
         "requests",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='edx-learndot',
-    version='0.1.0',
+    version='0.2.0',
     description="""Django app to integrate edX with LearnDot""",
     author='OpenCraft',
     url='https://github.com/open-craft/edxlearndot',
@@ -17,19 +17,17 @@ setup(
         'License :: OSI Approved :: GNU Affero General Public License v3',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
-        'Framework :: Django :: 1.10',
-        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
     ],
     packages=[
         'edxlearndot',
         'tests'
     ],
     install_requires=[
-        "django >= 1.8, < 2.0",
+        "django >= 3.0, < 3.1",
         "edx-opaque-keys",
         "python-dateutil",
         "requests",

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.5',
         'Framework :: Django',
+        'Framework :: Django :: 2.2.12',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
     ],
@@ -27,7 +28,7 @@ setup(
         'tests'
     ],
     install_requires=[
-        "django >= 3.0, < 3.1",
+        "django",
         "edx-opaque-keys",
         "python-dateutil",
         "requests",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.5',
         'Framework :: Django',
-        'Framework :: Django :: 2.2.12',
+        'Framework :: Django :: 2.2.13',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
     ],
@@ -28,7 +28,7 @@ setup(
         'tests'
     ],
     install_requires=[
-        "django",
+        "django>=2.2, >3, <3.1",
         "edx-opaque-keys",
         "python-dateutil",
         "requests",

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,9 @@ setenv =
 passenv = OPENEDX_REPO OPENEDX_REFERENCE_REPO OPENEDX_RELEASE
 
 deps =
-    django22: Django==2.2.12
-    django30: Django>=3.0,<3.1
     -rtest_requirements.txt
+    django22: Django==2.2.13
+    django30: Django>=3.0,<3.1
 
 commands =
     ./get_edx_platform.sh

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27}-django{18,111}, py27-quality
+envlist = py{35}-django{22}, py{38}-django{22,30}, py38-quality
 
 [testenv]
 
@@ -10,8 +10,8 @@ setenv =
 passenv = OPENEDX_REPO OPENEDX_REFERENCE_REPO OPENEDX_RELEASE
 
 deps =
-    django18: Django>=1.8,<1.9
-    django111: Django>=1.11,<2.0
+    django22: Django==2.2.12
+    django30: Django>=3.0,<3.1
     -rtest_requirements.txt
 
 commands =
@@ -19,7 +19,7 @@ commands =
     coverage run --source edxlearndot manage.py test
     coverage report
 
-[testenv:py27-quality]
+[testenv:py38-quality]
 
 commands =
     ./get_edx_platform.sh


### PR DESCRIPTION
Updated tox coverage tests to pass for the following envlist:
```
py{35}-django{22}, py{38}-django{22,30}, py38-quality
```

**JIRA tickets**: SE-2671

**Testing instructions**:

> Please note that I was not able to find `juniper.1`; therefore, the tests were run with `juniper.master`.

1. `export OPENEDX_RELEASE=open-release/juniper.master`
2. `tox`

**Author notes and concerns**:

1. I wasn't able to run the tests for `py{27-django{18,111}` because of the problem with my machine, discussed on SE-2671.
2. The code edits I have done should keep support for Python 2.7.
3. The `setup.py` contains some `install_requires` which affect the actual requirements being installed with `tox`. Any suggestions on what to do? If I should groom it, or just rewrite it... 

Please let me know.

**Reviewers**
- [ ] @pomegranited 