### PR TITLE
[FAL-1711]: fixes models str method

### DIFF
--- a/edxlearndot/learndot.py
+++ b/edxlearndot/learndot.py
@@ -210,13 +210,13 @@ class LearndotAPIClient:
         """
         try:
             return settings.LEARNDOT_API_KEY
-        except AttributeError:
+        except AttributeError as attr_error:
             msg = (
                 "The Learndot API key could not be found in your Django settings. "
                 "Please add it as settings.LEARNDOT_API_KEY."
             )
             log.fatal(msg)
-            raise LearndotAPIException(msg)
+            raise LearndotAPIException(msg) from attr_error
 
     def get_api_base_url(self):
         """
@@ -224,13 +224,13 @@ class LearndotAPIClient:
         """
         try:
             return settings.LEARNDOT_API_BASE_URL
-        except AttributeError:
+        except AttributeError as attr_error:
             msg = (
                 "The Learndot API base URL could not be found in your Django settings. "
                 "Please add it as settings.LEARNDOT_API_BASE_URL."
             )
             log.fatal(msg)
-            raise LearndotAPIException(msg)
+            raise LearndotAPIException(msg) from attr_error
 
     def get_api_request_headers(self):
         """
@@ -283,7 +283,7 @@ class LearndotAPIClient:
         except requests.exceptions.HTTPError as e:
             msg = "Error looking up Learndot contact for user {}: {}".format(user, e)
             log.error(msg)
-            raise LearndotAPIException(msg)
+            raise LearndotAPIException(msg) from e
 
         contacts = response.json()["results"]
         contact_id = None
@@ -375,7 +375,7 @@ class LearndotAPIClient:
                 e
             )
             log.error(msg)
-            raise LearndotAPIException(msg)
+            raise LearndotAPIException(msg) from e
 
         enrolments = [e for e in response.json()["results"] if e["status"] != "CANCELLED"]
         enrolment_id = None
@@ -399,7 +399,7 @@ class LearndotAPIClient:
                     "by expiry date to determine the latest one. The error raised while sorting was: {}"
                 ).format(contact_id, component_id, e)
                 log.error(msg)
-                raise LearndotAPIException(msg)
+                raise LearndotAPIException(msg) from e
 
         if enrolment_id is not None:
             log.info(
@@ -470,7 +470,7 @@ class LearndotAPIClient:
         except requests.exceptions.HTTPError as e:
             msg = "Error trying to set status of enrolment {} to {}: {}".format(enrolment_id, status, e)
             log.error(msg)
-            raise LearndotAPIException(msg)
+            raise LearndotAPIException(msg) from e
 
         try:
             enrolment_status_log, _created = EnrolmentStatusLog.objects.get_or_create(

--- a/edxlearndot/management/commands/update_learndot_enrolments.py
+++ b/edxlearndot/management/commands/update_learndot_enrolments.py
@@ -17,7 +17,7 @@ from opaque_keys.edx.keys import CourseKey
 from lms.djangoapps.courseware.courses import get_course
 from lms.djangoapps.grades.config import should_persist_grades
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
-from student.models import CourseEnrollment
+from common.djangoapps.student.models import CourseEnrollment
 
 from edxlearndot.learndot import LearndotAPIClient
 from edxlearndot.models import CourseMapping

--- a/edxlearndot/models.py
+++ b/edxlearndot/models.py
@@ -19,13 +19,14 @@ class CourseMapping(models.Model):
         unique_together = ("learndot_component_id", "edx_course_key")
 
     def __str__(self):
-        return self.__unicode__().encode("utf8")
+        return str(self.__unicode__())
 
     def __unicode__(self):
         return "learndot_component_id={}, edx_course_key={}".format(
             self.learndot_component_id,
             self.edx_course_key
         )
+
 
 class EnrolmentStatusLog(models.Model):
     """A record of an update to a Learndot enrolment."""
@@ -42,7 +43,7 @@ class EnrolmentStatusLog(models.Model):
         app_label = "edxlearndot"
 
     def __str__(self):
-        return self.__unicode__().encode("utf8")
+        return str(self.__unicode__())
 
     def __unicode__(self):
         return "learndot_enrolment_id={}, status={} at {}".format(

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'tests'
     ],
     install_requires=[
-        "django>=2.2,<3",
+        "django>=2.2",
         "edx-opaque-keys",
         "python-dateutil",
         "requests",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -13,3 +13,4 @@ sortedcontainers
 tox
 xblock
 responses
+edx-django-utils

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,7 +9,7 @@ from django.test import TestCase
 
 from opaque_keys.edx.keys import CourseKey
 
-from edxlearndot.models import CourseMapping
+from edxlearndot.models import CourseMapping, EnrolmentStatusLog
 
 
 class CourseMappingTestCase(TestCase):
@@ -36,3 +36,13 @@ class CourseMappingTestCase(TestCase):
 
         with self.assertRaises(IntegrityError):
             CourseMapping.objects.create(learndot_component_id=1, edx_course_key=self.course1_key)
+
+    def test_model_str(self):
+        course_mapping = CourseMapping.objects.create(learndot_component_id=1, edx_course_key=self.course1_key)
+        self.assertEqual(str(course_mapping), f"learndot_component_id=1, edx_course_key={self.course1_key}")
+
+        sl = EnrolmentStatusLog.objects.create(learndot_enrolment_id=1)
+        self.assertEqual(
+            str(sl),
+            f"learndot_enrolment_id={sl.learndot_enrolment_id}, status={sl.status} at {sl.updated_at}",
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35}-django{22}, py{38}-django{22,30}, py38-quality
+envlist = py{38}-django{22,30}, py38-quality
 
 [testenv]
 


### PR DESCRIPTION
This PR is about fixing the access to the models from admin and in general

**JIRA tickets**: FAL-1711

**Testing instructions**:

- Install this inside an lms instance and try to access an Course Mapping object (`/admin/edxlearndot/coursemapping/`
- Go to the shell and make sure the `edxlearndot` are available as lms command (`./manage.py lms --help | grep learndot`)

**Reviewers**
- [ ] @pomegranited 