### PR TITLE
[FAL-1711] Reverted import change

### DIFF
--- a/edxlearndot/management/commands/update_learndot_enrolments.py
+++ b/edxlearndot/management/commands/update_learndot_enrolments.py
@@ -17,7 +17,7 @@ from opaque_keys.edx.keys import CourseKey
 from lms.djangoapps.courseware.courses import get_course
 from lms.djangoapps.grades.config import should_persist_grades
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
-from common.djangoapps.student.models import CourseEnrollment
+from student.models import CourseEnrollment
 
 from edxlearndot.learndot import LearndotAPIClient
 from edxlearndot.models import CourseMapping


### PR DESCRIPTION
This change reverts a change made to silence a deprecation warning, because it breaks compatibility with Juniper.
cf https://github.com/open-craft/edx-learndot/pull/12/files#r603045238

**Testing steps**

* Deploy this branch to a running Juniper instance.
* In the edxapp virtualenv, run the management command, and see that it completes successfully: 
   ```
   ./manage.py lms update_learndot_enrolments
   ```

**Author Notes & Comments**

* After merging, the `v0.3` tag should either be replaced and recreated against the latest master,
  or a new tag created and the client's secure config updated to use this new tag.

**Reviewer**
- [ ] @eLRuLL 