### PR TITLE
[FAL-1711] Ensures the migrations and management command are installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='edx-learndot',
-    version='0.2.0',
+    version='0.4.0',
     description="""Django app to integrate edX with LearnDot""",
     author='OpenCraft',
     url='https://github.com/open-craft/edxlearndot',
@@ -25,7 +25,8 @@ setup(
     ],
     packages=[
         'edxlearndot',
-        'tests'
+        'edxlearndot.migrations',
+        'edxlearndot.management.commands',
     ],
     install_requires=[
         "django>=2.2",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """ Setup to allow pip installs of edx-learndot module """
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='edx-learndot',
@@ -23,11 +23,7 @@ setup(
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
     ],
-    packages=[
-        'edxlearndot',
-        'edxlearndot.migrations',
-        'edxlearndot.management.commands',
-    ],
+    packages=find_packages(include=['edxlearndot', 'edxlearndot.*']),
     install_requires=[
         "django>=2.2",
         "edx-opaque-keys",


### PR DESCRIPTION
Updates the package install targets to insure that migrations and the management command are installed with this package.
Also bumps the version to 0.4.0 in preparation for new tag.

These changes were required to make this plugin work with Open edX Koa, but we're not sure why. Maybe there are package management changes with python 3.8.5?

**Testing instructions**
1. Install this branch on a running Koa instance (like cloudera-stage): 
   ```
   (edxapp) edxapp@cloudera:~/edx-platform$ pip install git+https://github.com/open-craft/edx-learndot.git@jill/fix-koa#egg=edx-learndot
   ```
1. Ensure you can see the management command: 
   ```
   (edxapp) edxapp@cloudera:~/edx-platform$ ./manage.py lms update_learndot_enrolments --help
   ...
   usage: manage.py update_learndot_enrolments [-h] [-u user] [-f] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH]
                                            [--traceback] [--no-color] [--force-color]
                                            [course_id [course_id ...]]

   Update Learndot enrolments based on grades in edX courses

   positional arguments:
     course_id             If course IDs are given, only update enrollments for those courses.

   optional arguments:
     -h, --help            show this help message and exit
     -u user, --username user
                        If usernames are given, only update enrollments for those users.
     -f, --force           Skip the usual attempt to avoid API calls for enrolments that have already been updated, and just send Learndot all
                        current enrolment status information.
     --version             show program's version number and exit
     -v {0,1,2,3}, --verbosity {0,1,2,3}
                        Verbosity level; 0=minimal output, 1=normal output, 2=verbose output, 3=very verbose output
     --settings SETTINGS   The Python path to a settings module, e.g. "myproject.settings.main". If this isn't provided, the DJANGO_SETTINGS_MODULE
                        environment variable will be used.
     --pythonpath PYTHONPATH
                        A directory to add to the Python path, e.g. "/home/djangoprojects/myproject".
     --traceback           Raise on CommandError exceptions
     --no-color            Don't colorize the command output.
     --force-color         Force colorization of the command output.
1. Ensure you can run the migrations:
   ```
   (edxapp) edxapp@cloudera:~/edx-platform$ ./manage.py lms migrate edxlearndot
   ```

**Reviewer**

- [ ] @eLRuLL 