### PR TITLE
FAL-1711 Performs exact match on email when searching for Learndot contacts

### DIFF
--- a/edxlearndot/learndot.py
+++ b/edxlearndot/learndot.py
@@ -287,6 +287,10 @@ class LearndotAPIClient:
 
         contacts = response.json()["results"]
         contact_id = None
+
+        # Learndot API query doesn't use exact matching, so filter out any contacts whose emails don't match.
+        contacts = [c for c in contacts if c["email"] == user.email]
+
         if len(contacts) == 1:
             contact_id = contacts[0]["id"]
         elif len(contacts) > 1:

--- a/edxlearndot/learndot.py
+++ b/edxlearndot/learndot.py
@@ -63,8 +63,9 @@ class LearndotAPIException(Exception):
             429 Too Many Requests
             504 Gateway Timeout
         """
+        str_e = str(exception)
         if (isinstance(exception, cls) and (
-                ("429" in str(exception)) or ("504" in str(exception)))):
+                ("429" in str_e) or ("504" in str_e) or ("502" in str_e))):
             log.warning("Retrying...")
             return True
         return False

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='edx-learndot',
-    version='0.4.0',
+    version='0.5.0',
     description="""Django app to integrate edX with LearnDot""",
     author='OpenCraft',
     url='https://github.com/open-craft/edxlearndot',

--- a/tests/test_learndot.py
+++ b/tests/test_learndot.py
@@ -316,6 +316,7 @@ class TestLearndotAPIClient(TestCase):
         # Retried API errors
         (429, 'Retrying...'),   # Too Many Requests
         (504, 'Retrying...'),   # Gateway Timeout
+        (502, 'Retrying...'),   # Rate limit
 
         # Just error out, no retries
         (400, None),            # Bad Request

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,7 +27,10 @@ class LearndotAPIClientMock(LearndotAPIClient):
         responses.add(
             responses.POST,
             self.get_contact_search_url(),
-            json={"results": [{"id": 1, "_displayName_": "Test Name", "email": "test@gmail.com"}]}
+            json={"results": [
+                {"id": 1, "_displayName_": "Test Name", "email": "test@gmail.com"},
+                {"id": 2, "_displayName_": "Test Name 2", "email": "rc.test@gmail.com"},
+            ]}
         )
         return super(LearndotAPIClientMock, self).get_contact_id(user)
 


### PR DESCRIPTION
The Learndot API doesn't use exact matching when we search for a contact by email, and so is returning multiple contacts when the email partially matches.

This PR enforces exact matching when fetching contacts.

Also, since we're getting periodic 502 errors from Learndot, this PR also retries (after the configured wait time) when it receives a 502.

**Testing instructions**

1. Run `tox` with the `master` version of the learndot client, but this branch's version of the mock test data:
   ```
   git checkout jill/fix-duplicate-contacts tests/utils.py
   git checkout master edxlearndot/learndot.py
   # Set up OPENEDX_* env vars as per README#testing
   tox
   ```
   Ensure the `get_contact_id` test fails with error "Multiple Learndot contacts found for user test"
1. Run `tox` with this branch's learndot client code, and ensure tests pass again.

**Reviewer**

- [ ] @eLRuLL 