### PR TITLE
FAL-1811: adds date range support for enrolments and tests

### DIFF
--- a/edxlearndot/management/commands/update_learndot_enrolments.py
+++ b/edxlearndot/management/commands/update_learndot_enrolments.py
@@ -10,6 +10,7 @@ import logging
 import sys
 
 import dateparser
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from opaque_keys import InvalidKeyError
@@ -104,8 +105,9 @@ class Command(BaseCommand):
         # course grade for each enrolled user, and if the user has passed,
         # update the Learndot enrolment
 
-        end_enrollments_date = dateparser.parse(options["end"])
-        start_enrolments_date = dateparser.parse(options["start"])
+        date_settings = {'TIMEZONE': settings.TIME_ZONE, 'RETURN_AS_TIMEZONE_AWARE': True}
+        end_enrollments_date = dateparser.parse(options["end"], settings=date_settings)
+        start_enrolments_date = dateparser.parse(options["start"], settings=date_settings)
 
         for cm in course_mappings:
             try:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=[
         "django>=2.2",
         "edx-opaque-keys",
-        "python-dateutil",
+        "dateparser",
         "requests",
         "retrying>=1.3,<2.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='edx-learndot',
-    version='0.5.0',
+    version='0.6.0',
     description="""Django app to integrate edX with LearnDot""",
     author='OpenCraft',
     url='https://github.com/open-craft/edxlearndot',

--- a/testing/testsettings.py
+++ b/testing/testsettings.py
@@ -21,6 +21,8 @@ INSTALLED_APPS = (
     "edxlearndot"
 )
 
+USE_TZ = True
+
 SECRET_KEY = "insecure-secret-key"
 
 LEARNDOT_API_BASE_URL = 'http://learndot/'

--- a/tests/test_learndot.py
+++ b/tests/test_learndot.py
@@ -382,7 +382,6 @@ class TestLearndotCommands(TestCase):
                 enrollments[timezone.now() - datetime.timedelta(days=30)] = MagicMock()
             output = []
             for enrollment_date, enrollment_mock in enrollments.items():
-                print(enrollment_date)
                 if created__range[0] <= enrollment_date <= created__range[1]:
                     output.append(enrollment_mock)
             return output


### PR DESCRIPTION
this PR includes date range support for enrolments  in the `update_learndot_enrolments` management command.

**Reviewers**:
- [x] @pomegranited 